### PR TITLE
canOnlyStartDatePick が trueの場合に決定ボタンを押せるようにする

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -1024,7 +1024,7 @@
 
         updateFormInputs: function() {
 
-            if (this.singleDatePicker || (this.endDate && (this.startDate.isBefore(this.endDate) || this.startDate.isSame(this.endDate)))) {
+            if (this.singleDatePicker || this.canOnlyStartDatePick || (this.endDate && (this.startDate.isBefore(this.endDate) || this.startDate.isSame(this.endDate)))) {
                 this.container.find('button.applyBtn').removeAttr('disabled');
             } else {
                 this.container.find('button.applyBtn').attr('disabled', 'disabled');


### PR DESCRIPTION
canOnlyStartDatePick が trueの場合に、end-dateが無くても決定ボタンを押せるようにする

#1 の対応漏れ